### PR TITLE
Base all relative paths from the project path, not from cwd

### DIFF
--- a/ESLint-Formatter.py
+++ b/ESLint-Formatter.py
@@ -174,7 +174,12 @@ class PluginUtils:
     if realpath:
       return os.path.realpath(os.path.expanduser(path))
     else:
-      return os.path.abspath(os.path.expanduser(path))
+      project_dir = sublime.active_window().project_file_name()
+      if project_dir:
+        cwd = os.path.dirname(project_dir)
+      else:
+        cwd = os.getcwd()
+      return os.path.normpath(os.path.join(cwd, os.path.expanduser(path)))
 
   # Yield path and every directory above path.
   @staticmethod


### PR DESCRIPTION
I have a project in Sublime Text 3 that includes `.` as one of its folders. Snipped down, it looks like this:
```json
{
    "folders":
    [
        {
            "path": ".",
            "name": "Project"
        }
    ]
}
```
With this project, `PluginUtils.project_path()` returns `"."` which is then expanded with cwd (`"C:\Program Files\Sublime Text 3"` for me) and fails to find eslint.

This pull request uses a base dir of the project itself, then fails back to cwd if there's no project open.