### PR TITLE
Use the new single-window settings

### DIFF
--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -12,67 +12,72 @@
   "id": "preferences",
   "children": [{
     "id": "package-settings",
-    "children": [{
-      "caption": "ESLint Formatter",
-      "children": [{
-        "command": "open_file",
-        "args": {
-          "file": "${packages}/ESLint-Formatter/ESLint-Formatter.sublime-settings"
-        },
-        "caption": "Settings – Default"
-      }, {
-        "command": "open_file",
-        "args": {
-          "file": "${packages}/User/ESLint-Formatter.sublime-settings"
-        },
-        "caption": "Settings – User"
-      }, {
-        "caption": "-"
-      }, {
-        "command": "open_file",
-        "args": {
-          "file": "${packages}/ESLint-Formatter/Default (OSX).sublime-keymap",
-          "platform": "OSX"
-        },
-        "caption": "Key Bindings – Default"
-      }, {
-        "command": "open_file",
-        "args": {
-          "file": "${packages}/ESLint-Formatter/Default (Linux).sublime-keymap",
-          "platform": "Linux"
-        },
-        "caption": "Key Bindings – Default"
-      }, {
-        "command": "open_file",
-        "args": {
-          "file": "${packages}/ESLint-Formatter/Default (Windows).sublime-keymap",
-          "platform": "Windows"
-        },
-        "caption": "Key Bindings – Default"
-      }, {
-        "command": "open_file",
-        "args": {
-          "file": "${packages}/User/Default (OSX).sublime-keymap",
-          "platform": "OSX"
-        },
-        "caption": "Key Bindings – User"
-      }, {
-        "command": "open_file",
-        "args": {
-          "file": "${packages}/User/Default (Linux).sublime-keymap",
-          "platform": "Linux"
-        },
-        "caption": "Key Bindings – User"
-      }, {
-        "command": "open_file",
-        "args": {
-          "file": "${packages}/User/Default (Windows).sublime-keymap",
-          "platform": "Windows"
-        },
-        "caption": "Key Bindings – User"
-      }, {
-        "caption": "-"
+    "children": [
+      {
+        "caption": "ESLint Formatter",
+        "children": [
+          {
+            "caption": "Settings",
+            "command": "edit_settings",
+            "args": {
+              "base_file": "${packages}/ESLint-Formatter/ESLint-Formatter.sublime-settings",
+              "default": "// Settings in here override those in \"ESLint-Formatter/ESLint-Formatter.sublime-settings\",\n\n{\n\t$0\n}\n"
+            }
+          },
+          {
+            "caption": "-"
+          }, 
+          {
+            "command": "open_file",
+            "args": {
+              "file": "${packages}/ESLint-Formatter/Default (OSX).sublime-keymap",
+              "platform": "OSX"
+            },
+            "caption": "Key Bindings – Default"
+          }, 
+          {
+            "command": "open_file",
+            "args": {
+              "file": "${packages}/ESLint-Formatter/Default (Linux).sublime-keymap",
+              "platform": "Linux"
+            },
+            "caption": "Key Bindings – Default"
+          }, 
+          {
+            "command": "open_file",
+            "args": {
+              "file": "${packages}/ESLint-Formatter/Default (Windows).sublime-keymap",
+              "platform": "Windows"
+            },
+            "caption": "Key Bindings – Default"
+          }, 
+          {
+            "command": "open_file",
+            "args": {
+              "file": "${packages}/User/Default (OSX).sublime-keymap",
+              "platform": "OSX"
+            },
+            "caption": "Key Bindings – User"
+          }, 
+          {
+            "command": "open_file",
+            "args": {
+              "file": "${packages}/User/Default (Linux).sublime-keymap",
+              "platform": "Linux"
+            },
+            "caption": "Key Bindings – User"
+          }, 
+          {
+            "command": "open_file",
+            "args": {
+              "file": "${packages}/User/Default (Windows).sublime-keymap",
+              "platform": "Windows"
+            },
+            "caption": "Key Bindings – User"
+          }, 
+          {
+            "caption": "-"
+          }]
       }]
-    }]
   }]
 }]


### PR DESCRIPTION
Use a single windows for setting. Default and user settings are shown side-by-side