### PR TITLE
Better lookup for the first eslint installed in the project tree

### DIFF
--- a/ESLint-Formatter.py
+++ b/ESLint-Formatter.py
@@ -200,7 +200,7 @@ class PluginUtils:
       normdn = PluginUtils.normalize_path(project_path)
     else:
       normdn = PluginUtils.normalize_path(dirname)
-      
+
     for d in PluginUtils.walk_up(normdn):
       matches = glob.glob(os.path.join(d, pattern))
       if matches:

--- a/ESLint-Formatter.py
+++ b/ESLint-Formatter.py
@@ -200,8 +200,7 @@ class PluginUtils:
       normdn = PluginUtils.normalize_path(project_path)
     else:
       normdn = PluginUtils.normalize_path(dirname)
-
-    
+      
     for d in PluginUtils.walk_up(normdn):
       matches = glob.glob(os.path.join(d, pattern))
       if matches:

--- a/ESLint-Formatter.py
+++ b/ESLint-Formatter.py
@@ -201,6 +201,7 @@ class PluginUtils:
     else:
       normdn = PluginUtils.normalize_path(dirname)
 
+    
     for d in PluginUtils.walk_up(normdn):
       matches = glob.glob(os.path.join(d, pattern))
       if matches:
@@ -210,13 +211,14 @@ class PluginUtils:
 
   @staticmethod
   def get_local_eslint(dirname):
-    pkg = PluginUtils.findup('package.json', dirname)
+    pkg = PluginUtils.findup('node_modules/eslint', dirname)
     if pkg == None:
       return None
     else:
       path = PluginUtils.get_pref("local_eslint_path").get(sublime.platform())
-      d = os.path.dirname(pkg)
+      d = os.path.dirname(os.path.dirname(pkg))
       esl = os.path.join(d, path)
+
       if os.path.isfile(esl):
         return esl
       else:


### PR DESCRIPTION
It looks now for `node_modules/eslint` folder which should be a reliable way to determine where
eslint is installed.
Close #52