### PR TITLE
WSL Support

### DIFF
--- a/ESLint-Formatter.sublime-settings
+++ b/ESLint-Formatter.sublime-settings
@@ -46,6 +46,13 @@
     "babel"
   ],
 
+  // Setting this to true will allow you to use
+  // WSL(https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux)
+  // for your node/npm installation.
+  // Note: Be sure to set your node_path.windows to "node"
+  //     and that node is in your WSL's PATH.
+  "wsl": false,
+    
   // logs eslint output messages to console when set to true
   "debug": false
 }


### PR DESCRIPTION
This PR provides the ability to use WSL (https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux) for your node/npm installations while running Sublime Text on your Windows host.

# New Configuration Option
```
  // Setting this to true will allow you to use
  // WSL(https://en.wikipedia.org/wiki/Windows_Subsystem_for_Linux)
  // for your node/npm installation.
  // Note: Be sure to set your node_path.windows to "node"
  //     and that node is in your WSL's PATH.
  "wsl": false
```

setting `wsl` to true will run `node` within your WSL given that `wsl` is in your host's **$PATH** and given that your `node_path.windows` is in your WSL's **$PATH**