### PR TITLE
feat: support eslint_d stdio

### DIFF
--- a/ESLint-Formatter.sublime-settings
+++ b/ESLint-Formatter.sublime-settings
@@ -29,7 +29,7 @@
   // Passed to eslint as --config. Read more here:
   // http://eslint.org/docs/user-guide/command-line-interface#c---config
   // If an absolute path is provided, it will use as is.
-  // Else, it will look for the file in the root of the project directory. 
+  // Else, it will look for the file in the root of the project directory.
   // Failing either, it will skip the config file
   "config_path": "",
 
@@ -44,6 +44,10 @@
 
   // Automatically format when a file is saved.
   "format_on_save": false,
+
+  // Use --fix-to-stdout, --stdin, and --stdin-filename to update the file if using eslint_d.
+  // See https://github.com/mantoni/eslint_d.js#automatic-fixing
+  "fix_to_stdout": false,
 
   // Only attempt to format files with whitelisted extensions on save.
   // Leave empty to disable the check


### PR DESCRIPTION
The `eslint_d` project supports a [--fix-to-stdout flag](https://github.com/mantoni/eslint_d.js#automatic-fixing) that emits the fixed code to the standard output, and accepts the code from the standard input. This offers a better user experience, so I'd like to support it via configuration. Happy to add docs if this is an acceptable feature!

Offers a solution to #71; fixes #62.