### PR TITLE
fix: stop showing error dialog for eslint failures

### DIFF
--- a/ESLint-Formatter.py
+++ b/ESLint-Formatter.py
@@ -288,7 +288,7 @@ class PluginUtils:
 
     if stderr:
       raise Exception('Error: %s' % stderr)
-    elif p.returncode != 0:
+    elif p.returncode == 127:
       raise Exception('Error: %s' % (stderr or stdout))
     else:
       return stdout


### PR DESCRIPTION
Added this to help diagnose path-related problems, inadvertently made the UX worse.

Fixes #79.