### PR TITLE
Added ability to set cwd dynamically by searching for config file

### DIFF
--- a/ESLint-Formatter.py
+++ b/ESLint-Formatter.py
@@ -70,12 +70,32 @@ class FormatEslintCommand(sublime_plugin.TextCommand):
     buffer_text = self.view.substr(region)
     return buffer_text
 
+  def walk_up_for_config(self, cdir, configFile):
+    if (cdir is None or configFile is None):
+      return
+
+    files = [file for file in os.listdir(cdir) if os.path.isfile(os.path.join(cdir, file))]
+    if configFile in files: 
+      return cdir
+
+    parent = os.path.dirname(cdir)
+    if (parent is cdir):
+      return parent
+
+    return self.walk_up_for_config(parent, configFile)
+
   def get_lint_directory(self, filename):
     project_path = PluginUtils.project_path(None)
     if project_path is not None:
       return PluginUtils.normalize_path(project_path)
+
     if filename is not None:
       cdir = os.path.dirname(filename)
+      configFile = PluginUtils.get_pref('config_file')
+      if (configFile):
+        foundCwd = self.walk_up_for_config(cdir, configFile)
+        if foundCwd:
+          return foundCwd
       if os.path.exists(cdir): return cdir
     return os.getcwd()
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,13 @@ By default, ESLintFormatter will supply the following settings:
   // Failing either, it will skip the config file
   "config_path": "",
 
+  // Specify the name of a config file, which determines the root of your
+  // project. This is a pattern such as ".eslintrc.json" or "package.json"
+  // and will be searched for upwards, to determine the working directory
+  // for linting. This is different to config_path and is only used for
+  // resolving the working directory.
+  "config_file": "",
+
   // Pass additional arguments to eslint.
   //
   // Each command should be a string where it supports the following replacements:

--- a/messages.json
+++ b/messages.json
@@ -11,5 +11,6 @@
     "2.3.1": "messages/2.3.1.txt",
     "2.4.0": "messages/2.4.0.txt",
     "2.4.1": "messages/2.4.1.txt",
-    "2.4.2": "messages/2.4.2.txt"
+    "2.4.2": "messages/2.4.2.txt",
+    "2.4.3": "messages/2.4.3.txt"
 }

--- a/messages/2.4.3.txt
+++ b/messages/2.4.3.txt
@@ -1,0 +1,3 @@
+ESLint-Formatter 2.4.3 changelog
+
+[Fix] Added new `config_file` option to allow better working directory resolution


### PR DESCRIPTION
Fixes #89 by providing a way of determining the root of the project, to set the current working directory when running the linter. This allows `eslint_d` to use it's caching when pulling out a separate tabbed window which massively improves performance.