### PR TITLE
fix: Logic to only show error on non-error cmd exit only if stderr exists

### DIFF
--- a/ESLint-Formatter.py
+++ b/ESLint-Formatter.py
@@ -308,7 +308,7 @@ class PluginUtils:
 
     if p.returncode == 127:
       raise Exception('Error: %s' % (stderr or stdout))
-    elif stderr && p.returncode != 0:
+    elif stderr and p.returncode != 0:
       raise Exception('Error: %s' % stderr)
     else:
       return stdout

--- a/ESLint-Formatter.py
+++ b/ESLint-Formatter.py
@@ -308,7 +308,7 @@ class PluginUtils:
 
     if p.returncode == 127:
       raise Exception('Error: %s' % (stderr or stdout))
-    elif p.returncode != 0:
+    elif stderr && p.returncode != 0:
       raise Exception('Error: %s' % stderr)
     else:
       return stdout

--- a/messages.json
+++ b/messages.json
@@ -13,5 +13,6 @@
     "2.4.1": "messages/2.4.1.txt",
     "2.4.2": "messages/2.4.2.txt",
     "2.4.3": "messages/2.4.3.txt",
-    "2.4.4": "messages/2.4.4.txt"
+    "2.4.4": "messages/2.4.4.txt",
+    "2.4.5": "messages/2.4.5.txt"
 }

--- a/messages/2.4.5.txt
+++ b/messages/2.4.5.txt
@@ -1,0 +1,3 @@
+ESLint-Formatter 2.4.5 changelog
+
+[Fix] Presenting error dialog on any unfixable ESLint error, Bug reported here https://github.com/elicwhite/ESLint-Formatter/issues/97. 


### PR DESCRIPTION
Fix #97